### PR TITLE
Pass req to callback

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,7 +20,7 @@ function Strategy(options, verify, issue) {
   }
   if (!verify) throw new Error('remember me cookie authentication strategy requires a verify function');
   if (!issue) throw new Error('remember me cookie authentication strategy requires an issue function');
-
+  
   var opts = { path: '/', httpOnly: true, maxAge: 604800000 }; // maxAge: 7 days
   this._key = options.key || 'remember_me';
   this._opts = utils.merge(opts, options.cookie);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,11 +20,12 @@ function Strategy(options, verify, issue) {
   }
   if (!verify) throw new Error('remember me cookie authentication strategy requires a verify function');
   if (!issue) throw new Error('remember me cookie authentication strategy requires an issue function');
-  
+
   var opts = { path: '/', httpOnly: true, maxAge: 604800000 }; // maxAge: 7 days
   this._key = options.key || 'remember_me';
   this._opts = utils.merge(opts, options.cookie);
-  
+  this._passReqToCallback = options.passReqToCallback;
+
   passport.Strategy.call(this);
   this.name = 'remember-me';
   this._verify = verify;
@@ -94,10 +95,18 @@ Strategy.prototype.authenticate = function(req, options) {
       return self.success(user, info);
     }
     
-    self._issue(user, issued);
+    if (self._passReqToCallback) {
+      self._issue(req, user, issued);
+    } else {
+      self._issue(user, issued);
+    }
   }
   
-  self._verify(token, verified);
+  if (self._passReqToCallback) {
+    self._verify(req, token, verified);
+  } else {
+    self._verify(token, verified);
+  }
 }
 
 


### PR DESCRIPTION
I was missing passReqToCallback on this strategy :)  I used request in the callbacks to scope the tokens based on a custom request header item.  This allows users to "remember me" across devices/clients.  
