### PR TITLE
implement the "passReqToCallback" option for this strategy

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -29,6 +29,7 @@ function Strategy(options, verify, issue) {
   this.name = 'remember-me';
   this._verify = verify;
   this._issue = issue;
+  this._passReqToCallback = !!options.passReqToCallback;
 }
 
 /**
@@ -94,10 +95,16 @@ Strategy.prototype.authenticate = function(req, options) {
       return self.success(user, info);
     }
     
-    self._issue(user, issued);
+    if (this._passReqToCallback)
+      self._issue(req, user, issued);
+    else
+      self._issue(user, issued);
   }
   
-  self._verify(token, verified);
+  if (this._passReqToCallback)
+    self._verify(req, token, verified);
+  else
+    self._verify(token, verified);
 }
 
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,11 +20,11 @@ function Strategy(options, verify, issue) {
   }
   if (!verify) throw new Error('remember me cookie authentication strategy requires a verify function');
   if (!issue) throw new Error('remember me cookie authentication strategy requires an issue function');
-  
+
   var opts = { path: '/', httpOnly: true, maxAge: 604800000 }; // maxAge: 7 days
   this._key = options.key || 'remember_me';
   this._opts = utils.merge(opts, options.cookie);
-  
+
   passport.Strategy.call(this);
   this.name = 'remember-me';
   this._verify = verify;
@@ -48,24 +48,24 @@ Strategy.prototype.authenticate = function(req, options) {
   // authenticated.  This is in preference to the session, which is typically
   // established at the same time the remember me cookie is issued.
   if (req.isAuthenticated()) { return this.pass(); }
-  
+
   var token = req.cookies[this._key];
-  
+
   // Since the remember me cookie is primarily a convenience, the lack of one is
   // not a failure.  In this case, a response should be rendered indicating a
   // logged out state, rather than denying the request.
   if (!token) { return this.pass(); }
-  
+
   var self = this;
-  
+
   function verified(err, user, info) {
     if (err) { return self.error(err); }
-    
+
     // Express exposes the response to the request.  We need the response to set
     // a cookie, so we'll grab it this way.  This breaks the encapsulation of
     // Passport's Strategy API, but is acceptable for this strategy.
     var res = req.res;
-    
+
     if (!user) {
       // The remember me cookie was not valid.  However, because this
       // authentication method is primarily a convenience, we don't want to
@@ -80,11 +80,11 @@ Strategy.prototype.authenticate = function(req, options) {
       //   http://jaspan.com/improved_persistent_login_cookie_best_practice
       //   http://web.archive.org/web/20130214051957/http://jaspan.com/improved_persistent_login_cookie_best_practice
       //   http://stackoverflow.com/questions/549/the-definitive-guide-to-forms-based-website-authentication
-      
+
       res.clearCookie(self._key);
       return self.pass();
     }
-    
+
     // The remember me cookie was valid and consumed.  For security reasons,
     // the just-used token should have been invalidated by the application.
     // A new token will be issued and set as the value of the remember me
@@ -94,14 +94,14 @@ Strategy.prototype.authenticate = function(req, options) {
       res.cookie(self._key, val, self._opts);
       return self.success(user, info);
     }
-    
-    if (this._passReqToCallback)
+
+    if (self._passReqToCallback)
       self._issue(req, user, issued);
     else
       self._issue(user, issued);
   }
-  
-  if (this._passReqToCallback)
+
+  if (self._passReqToCallback)
     self._verify(req, token, verified);
   else
     self._verify(token, verified);
@@ -110,5 +110,5 @@ Strategy.prototype.authenticate = function(req, options) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;


### PR DESCRIPTION
inline with other/standard strategies, this PR implements the boolean  "passReqToCallback" option for strategy initialization so that users can opt to have the `Request` object passed as the first argument to this strategy's `verify` and `issue` callbacks.

PS - sorry about the bogus white space changes. 
