### PR TITLE
Fixing user serialization bug with passport v0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport": "~0.1.1"
+    "passport": "~0.3.0"
   },
   "devDependencies": {
     "mocha": "1.x.x",


### PR DESCRIPTION
This fixes an issue where the user attribute cannot be set on undefined by simply upgrading the passport dependency to the latest v0.3.0.

Thanks for merging!
