### PR TITLE
Add koa.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module lets you authenticate using a remember me cookie (aka persistent
 login) in your Node.js applications.  By plugging into Passport, remember me
 authentication can be easily and unobtrusively integrated into any application
 or framework that supports [Connect](http://www.senchalabs.org/connect/)-style
-middleware, including [Express](http://expressjs.com/).
+middleware, including [Express](http://expressjs.com/) and [Koa](http://koajs.com).
 
 ## Install
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -3,6 +3,7 @@
  */
 var passport = require('passport')
   , util = require('util')
+  , Cookies = require('cookies')
   , utils = require('./utils');
 
 
@@ -48,7 +49,8 @@ Strategy.prototype.authenticate = function(req, options) {
   // established at the same time the remember me cookie is issued.
   if (req.isAuthenticated()) { return this.pass(); }
   
-  var token = req.cookies[this._key];
+  var cookies = new Cookies(req, req.res, this._opts);
+  var token = cookies.get(this._key);
   
   // Since the remember me cookie is primarily a convenience, the lack of one is
   // not a failure.  In this case, a response should be rendered indicating a
@@ -80,7 +82,7 @@ Strategy.prototype.authenticate = function(req, options) {
       //   http://web.archive.org/web/20130214051957/http://jaspan.com/improved_persistent_login_cookie_best_practice
       //   http://stackoverflow.com/questions/549/the-definitive-guide-to-forms-based-website-authentication
       
-      res.clearCookie(self._key);
+      cookies.set(self._key, null, { expires: new Date(1) });
       return self.pass();
     }
     
@@ -90,7 +92,7 @@ Strategy.prototype.authenticate = function(req, options) {
     // cookie.
     function issued(err, val) {
       if (err) { return self.error(err); }
-      res.cookie(self._key, val, self._opts);
+      cookies.set(self._key, val, self._opts);
       return self.success(user, info);
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-remember-me",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Remember Me cookie authentication strategy for Passport.",
   "keywords": ["passport", "cookie", "persistent", "rememberme", "auth", "authn", "authentication"],
   "repository": {


### PR DESCRIPTION
`req.cookie[key]`, `res.cookie()`, and `res.clearCookie()` are all valid for Express framework, but not compatible with Koa. So I replaced them with [cookies](https://github.com/pillarjs/cookies) module. Please take a review and I'll be happy to see it merged and new version published on npm repository. (otherwise I'll need to point to my github repo url in package.json for a while ;))